### PR TITLE
ci: Dilithium version bump to dilithium-v0.0.1

### DIFF
--- a/dilithium-crypto/Cargo.toml
+++ b/dilithium-crypto/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 name = "co-dilithium-crypto"
 readme = "README.md"
 repository = "https://github.com/quantus-labs/chain-rm"
-version = "0.1.0"
+version = "0.0.1"
 
 [dependencies]
 codec = { workspace = true, default-features = false }


### PR DESCRIPTION
## Dilithium Crypto Release Proposal

This PR proposes releasing **co-dilithium-crypto** version `0.0.1`.

### Changes
- Updated `dilithium-crypto/Cargo.toml` version to `0.0.1`
- Updated `Cargo.lock`

### Release Process
When this PR is merged, it will:
1. Create tag `dilithium-v0.0.1`
2. Run tests and build checks
3. Create GitHub release
4. Publish to crates.io (if not draft)

### Checklist
- [ ] Version number is correct
- [ ] All tests pass
- [ ] Documentation is up to date
- [ ] CHANGELOG updated (if applicable)

**Release Type:** Production
**Version Type:** patch
**Triggered by:** https://github.com/Quantus-Network/chain-rm/actions/runs/17639209421
