### PR TITLE
ci: Dilithium version bump to dilithium-v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "co-dilithium-crypto"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "env_logger 0.11.8",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ wasm-timer = { version = "0.2.5" }
 zeroize = { version = "1.7.0", default-features = false }
 
 # Own dependencies
-co-dilithium-crypto = { path = "./dilithium-crypto", version = "0.0.1", default-features = false }
+co-dilithium-crypto = { path = "./dilithium-crypto", version = "0.0.2", default-features = false }
 pallet-balances = { path = "./pallets/balances", default-features = false }
 pallet-merkle-airdrop = { path = "./pallets/merkle-airdrop", default-features = false }
 pallet-mining-rewards = { path = "./pallets/mining-rewards", default-features = false }

--- a/dilithium-crypto/Cargo.toml
+++ b/dilithium-crypto/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 name = "co-dilithium-crypto"
 readme = "README.md"
 repository = "https://github.com/quantus-labs/chain-rm"
-version = "0.0.1"
+version = "0.0.2"
 
 [dependencies]
 codec = { workspace = true, default-features = false }


### PR DESCRIPTION
## Dilithium Crypto Release Proposal

This PR proposes releasing **co-dilithium-crypto** version `0.0.2`.

### Changes
- Updated `dilithium-crypto/Cargo.toml` version to `0.0.2`
- Updated `Cargo.toml` workspace dependency version to `0.0.2`
- Updated `Cargo.lock`

### Release Process
When this PR is merged, it will:
1. Create tag `dilithium-v0.0.2`
2. Run tests and build checks
3. Create GitHub release
4. Publish to crates.io (if not draft)

### Checklist
- [ ] Version number is correct
- [ ] All tests pass
- [ ] Documentation is up to date
- [ ] CHANGELOG updated (if applicable)

**Release Type:** Production
**Version Type:** patch
**Triggered by:** https://github.com/Quantus-Network/chain-rm/actions/runs/17640356560
