### PR TITLE
ci: Dilithium version bump to dilithium-v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8169,7 +8169,7 @@ dependencies = [
 
 [[package]]
 name = "qp-dilithium-crypto"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "env_logger 0.11.8",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ pallet-qpow = { path = "./pallets/qpow", default-features = false }
 pallet-reversible-transfers = { path = "./pallets/reversible-transfers", default-features = false }
 pallet-scheduler = { path = "./pallets/scheduler", default-features = false }
 pallet-wormhole = { path = "./pallets/wormhole", default-features = false }
-qp-dilithium-crypto = { path = "./primitives/dilithium-crypto", version = "0.1.1", default-features = false }
+qp-dilithium-crypto = { path = "./primitives/dilithium-crypto", version = "0.1.2", default-features = false }
 qp-scheduler = { path = "./primitives/scheduler", default-features = false }
 qp-wormhole = { path = "./primitives/wormhole", default-features = false }
 qpow-math = { path = "./qpow-math", default-features = false }

--- a/primitives/dilithium-crypto/Cargo.toml
+++ b/primitives/dilithium-crypto/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 name = "qp-dilithium-crypto"
 readme = "README.md"
 repository = "https://github.com/Quantus-Network/chain"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 codec = { workspace = true, default-features = false }


### PR DESCRIPTION
## Dilithium Crypto Release Proposal

This PR proposes releasing **qp-dilithium-crypto** version `0.1.2`.

### Changes
- Updated `primitives/dilithium-crypto/Cargo.toml` version to `0.1.2`
- Updated `Cargo.toml` workspace dependency version to `0.1.2`
- Updated `Cargo.lock`
