### PR TITLE
ci: Miner API version bump to quantus-miner-api-v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8970,7 +8970,7 @@ dependencies = [
 
 [[package]]
 name = "qu-miner-api"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ qp-dilithium-crypto = { path = "./primitives/dilithium-crypto", version = "0.1.1
 qp-scheduler = { path = "./primitives/scheduler", default-features = false }
 qp-wormhole = { path = "./primitives/wormhole", default-features = false }
 qpow-math = { path = "./qpow-math", default-features = false }
-qu-miner-api = { path = "./miner-api", version = "0.0.1", default-features = false }
+qu-miner-api = { path = "./miner-api", version = "0.0.2", default-features = false }
 quantus-runtime = { path = "./runtime", default-features = false }
 sc-consensus-qpow = { path = "./client/consensus/qpow", default-features = false }
 sp-consensus-pow = { path = "./primitives/consensus/pow", default-features = false }

--- a/miner-api/Cargo.toml
+++ b/miner-api/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 license.workspace = true
 name = "qu-miner-api"
 repository.workspace = true
-version = "0.0.1"
+version = "0.0.2"
 
 [dependencies]
 serde = { workspace = true, features = ["alloc", "derive"] }


### PR DESCRIPTION
## Miner API Release Proposal

This PR proposes releasing **qu-miner-api** version `0.0.2`.

### Changes
- Updated `miner-api/Cargo.toml` version to `0.0.2`
- Updated `Cargo.toml` workspace dependency version to `0.0.2`
- Updated `Cargo.lock`
